### PR TITLE
Added support for grub2 loopback

### DIFF
--- a/overlay/image/boot/grub/grub.cfg
+++ b/overlay/image/boot/grub/grub.cfg
@@ -21,6 +21,11 @@ set gfxmode=auto
 set gfxterm_font="Unifont Regular 16"
 set theme=/boot/grub/theme/theme.txt
 
+if [ -n "${iso_path}" ]; then
+    isoboot="findiso=${iso_path}"
+    export isoboot
+fi
+
 function create_menu {
     set desc="$1"
     set lang="$2"
@@ -32,14 +37,14 @@ function create_menu {
         shift 1
         set options="$*"
         linux /vmlinuz boot=live quiet splash noprompt \
-            components=locales ${options}
+            components=locales ${options} ${isoboot}
         initrd /initrd
     }
 }
 
 menuentry "Redo Rescue $VERSION" --class redo {
     linux /vmlinuz boot=live quiet splash noprompt nocomponents \
-        setkmap=us
+        setkmap=us ${isoboot}
     initrd /initrd
 }
 
@@ -55,6 +60,6 @@ submenu "Choose language" --class locale {
 
 menuentry "Safe video mode" --class screen {
     linux /vmlinuz boot=live quiet splash noprompt nocomponents \
-        nomodeset toram setkmap=us
+        nomodeset toram setkmap=us ${isoboot}
     initrd /initrd
 }

--- a/overlay/image/boot/grub/loopback.cfg
+++ b/overlay/image/boot/grub/loopback.cfg
@@ -1,0 +1,1 @@
+source /boot/grub/grub.cfg


### PR DESCRIPTION
This PR allow to boot Redo Rescue ISO by [MultiOS-USB](https://github.com/Mexit/MultiOS-USB) or any grub2 (even on HDD) using simple [menu](https://supergrubdisk.org/wiki/Loopback.cfg).